### PR TITLE
feat: update patch function operation

### DIFF
--- a/src/openmetadata/openmetadata_client.py
+++ b/src/openmetadata/openmetadata_client.py
@@ -92,14 +92,16 @@ class OpenMetadataClient:
         endpoint: str,
         params: Optional[Dict[str, Any]] = None,
         json_data: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Make HTTP request to OpenMetadata API.
 
         Args:
-            method: HTTP method (GET, POST, PUT, DELETE)
+            method: HTTP method (GET, POST, PUT, DELETE, PATCH)
             endpoint: API endpoint path
             params: Query parameters
-            json_data: JSON payload for POST/PUT requests
+            json_data: JSON payload for POST/PUT/PATCH requests
+            headers: Additional HTTP headers
 
         Returns:
             API response as dictionary
@@ -110,7 +112,20 @@ class OpenMetadataClient:
         url = urljoin(self.base_url, endpoint)
 
         try:
-            response = self.session.request(method=method, url=url, params=params, json=json_data)
+            # Start with provided headers or empty dict
+            request_headers = dict(headers) if headers else {}
+
+            # Set Content-Type if not already provided and we have JSON data
+            if json_data is not None and "Content-Type" not in request_headers:
+                request_headers["Content-Type"] = "application/json"
+
+            response = self.session.request(
+                method=method,
+                url=url,
+                params=params,
+                json=json_data,
+                headers=request_headers
+            )
             response.raise_for_status()
             return response.json() if response.content else {}
         except httpx.HTTPStatusError as e:
@@ -131,8 +146,9 @@ class OpenMetadataClient:
         return self._make_request("PUT", endpoint, json_data=json_data)
 
     def patch(self, endpoint: str, json_data: Dict[str, Any]) -> Dict[str, Any]:
-        """Make PATCH request to OpenMetadata API."""
-        return self._make_request("PATCH", endpoint, json_data=json_data)
+        """Make PATCH request to OpenMetadata API with JSON Patch headers."""
+        headers = {"Content-Type": "application/json-patch+json"}
+        return self._make_request("PATCH", endpoint, json_data=json_data, headers=headers)
 
     def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> None:
         """Make DELETE request to OpenMetadata API."""

--- a/src/openmetadata/table.py
+++ b/src/openmetadata/table.py
@@ -147,19 +147,21 @@ async def create_table(
 
 async def update_table(
     table_id: str,
-    table_data: Dict[str, Any],
+    operations: List[Dict[str, Any]],
 ) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]:
-    """Update an existing table.
+    """Update an existing table using JSON Patch operations.
 
     Args:
         table_id: ID of the table to update
-        table_data: Updated table data
+        operations: JSON Patch operations. Commonly supported: add, remove, replace
+                   Example: [{"op": "add", "path": "/description", "value": "New description"}]
 
     Returns:
         List of MCP content types containing updated table details
     """
     client = get_client()
-    result = client.patch(f"tables/{table_id}", json_data=table_data)
+
+    result = client.patch(f"tables/{table_id}", json_data=operations)
 
     # Add UI URL for web interface integration
     table_fqn = result.get("fullyQualifiedName", "")


### PR DESCRIPTION
## Summary
Table update API의 HTTP method를 PUT에서 PATCH로 변경되었기 때문에 PATCH method 스펙에 맞춰 수정해줍니다.

content-type 값으로 method 마다 다른 값을 사용합니다.
- put: "application/json"
- patch: ""application/json-patch+json"

## Changes
- API 엔드포인트: Table update 관련 API
- 요청 형식: PATCH method에 맞는 부분 content-type 헤더 추가